### PR TITLE
Add benchmark for AsyncLocalStorage

### DIFF
--- a/benchmark/async_hooks/async-resource-vs-destroy.js
+++ b/benchmark/async_hooks/async-resource-vs-destroy.js
@@ -8,7 +8,8 @@ const common = require('../common.js');
 const {
   createHook,
   executionAsyncResource,
-  executionAsyncId
+  executionAsyncId,
+  AsyncLocalStorage
 } = require('async_hooks');
 const { createServer } = require('http');
 
@@ -18,7 +19,7 @@ const connections = 500;
 const path = '/';
 
 const bench = common.createBenchmark(main, {
-  type: ['async-resource', 'destroy'],
+  type: ['async-resource', 'destroy', 'async-local-storage'],
   asyncMethod: ['callbacks', 'async'],
   n: [1e6]
 });
@@ -102,6 +103,36 @@ function buildDestroy(getServe) {
   }
 }
 
+function buildAsyncLocalStorage(getServe) {
+  const asyncLocalStorage = new AsyncLocalStorage();
+  asyncLocalStorage.enable();
+  const server = createServer((req, res) => {
+    asyncLocalStorage.runSyncAndReturn(() => {
+      getServe(getCLS, setCLS)(req, res);
+    });
+  });
+
+  return {
+    server,
+    close
+  };
+
+  function getCLS() {
+    const store = asyncLocalStorage.getStore();
+    return store.get('store');
+  }
+
+  function setCLS(state) {
+    const store = asyncLocalStorage.getStore();
+    store.set('store', state);
+  }
+
+  function close() {
+    asyncLocalStorage.disable();
+    server.close();
+  }
+}
+
 function getServeAwait(getCLS, setCLS) {
   return async function serve(req, res) {
     setCLS(Math.random());
@@ -126,7 +157,8 @@ function getServeCallbacks(getCLS, setCLS) {
 
 const types = {
   'async-resource': buildCurrentResource,
-  'destroy': buildDestroy
+  'destroy': buildDestroy,
+  'async-local-storage': buildAsyncLocalStorage
 };
 
 const asyncMethods = {


### PR DESCRIPTION
* Adds a benchmark for `AsyncLocalStorage`

#26540 seems to be lacking any benchmarks. Here is what I got on my machine with this benchmark:
```bash
$ ./node benchmark/async_hooks/async-resource-vs-destroy.js benchmarker=autocannon
async_hooks/async-resource-vs-destroy.js n=1000000 asyncMethod="callbacks" type="async-resource" benchmarker="autocannon": 21,888.8
async_hooks/async-resource-vs-destroy.js n=1000000 asyncMethod="async" type="async-resource" benchmarker="autocannon": 17,479.2
async_hooks/async-resource-vs-destroy.js n=1000000 asyncMethod="callbacks" type="destroy" benchmarker="autocannon": 20,671.2
async_hooks/async-resource-vs-destroy.js n=1000000 asyncMethod="async" type="destroy" benchmarker="autocannon": 16,205.6
async_hooks/async-resource-vs-destroy.js n=1000000 asyncMethod="callbacks" type="async-local-storage" benchmarker="autocannon": 21,072.8
async_hooks/async-resource-vs-destroy.js n=1000000 asyncMethod="async" type="async-local-storage" benchmarker="autocannon": 16,541.6
```