### PR TITLE
Address Qard's review comments

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -933,7 +933,7 @@ instance will be exited.
 Calling `asyncLocalStorage.disable()` is required before the
 `asyncLocalStorage` can be garbage collected. This does not apply to stores
 provided by the `asyncLocalStorage`, as those objects are garbage collected
-along with the corresponding async resource.
+along with the corresponding async resources.
 
 This method is to be used when the `asyncLocalStorage` is not in use anymore
 in the current process.

--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -931,7 +931,9 @@ When calling `asyncLocalStorage.disable()`, all current contexts linked to the
 instance will be exited.
 
 Calling `asyncLocalStorage.disable()` is required before the
-`asyncLocalStorage` can be garbage collected.
+`asyncLocalStorage` can be garbage collected. This does not apply to stores
+provided by the `asyncLocalStorage`, as those objects are garbage collected
+along with the corresponding async resource.
 
 This method is to be used when the `asyncLocalStorage` is not in use anymore
 in the current process.
@@ -1069,7 +1071,7 @@ the context will be re-entered.
 Example:
 
 ```js
-// Within a call to run or runAsyncAndReturn
+// Within a call to run or runSyncAndReturn
 try {
   asyncLocalStorage.getStore(); // Returns a Map
   asyncLocalStorage.exitSyncAndReturn(() => {
@@ -1082,7 +1084,7 @@ try {
 }
 ```
 
-### Choosing between `run` and `runAsyncAndReturn`
+### Choosing between `run` and `runSyncAndReturn`
 
 #### When to choose `run`
 

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -291,13 +291,13 @@ class AsyncLocalStorage {
 
   run(callback, ...args) {
     this._enter();
-    process.nextTick(() => callback(...args));
+    process.nextTick(callback, ...args);
     this._exit();
   }
 
   exit(callback, ...args) {
     this.enabled = false;
-    process.nextTick(() => callback(...args));
+    process.nextTick(callback, ...args);
     this.enabled = true;
   }
 }

--- a/test/async-hooks/test-async-local-storage-args.js
+++ b/test/async-hooks/test-async-local-storage-args.js
@@ -1,0 +1,20 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { AsyncLocalStorage } = require('async_hooks');
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+asyncLocalStorage.run((runArg) => {
+  assert.strictEqual(runArg, 1);
+  asyncLocalStorage.exit((exitArg) => {
+    assert.strictEqual(exitArg, 2);
+  }, 2);
+}, 1);
+
+asyncLocalStorage.runSyncAndReturn((runArg) => {
+  assert.strictEqual(runArg, 'foo');
+  asyncLocalStorage.exit((exitArg) => {
+    assert.strictEqual(exitArg, 'bar');
+  }, 'bar');
+}, 'foo');

--- a/test/async-hooks/test-async-local-storage-args.js
+++ b/test/async-hooks/test-async-local-storage-args.js
@@ -14,7 +14,7 @@ asyncLocalStorage.run((runArg) => {
 
 asyncLocalStorage.runSyncAndReturn((runArg) => {
   assert.strictEqual(runArg, 'foo');
-  asyncLocalStorage.exit((exitArg) => {
+  asyncLocalStorage.exitSyncAndReturn((exitArg) => {
     assert.strictEqual(exitArg, 'bar');
   }, 'bar');
 }, 'foo');

--- a/test/async-hooks/test-async-local-storage-errors-async.js
+++ b/test/async-hooks/test-async-local-storage-errors-async.js
@@ -13,9 +13,8 @@ process.setUncaughtExceptionCaptureCallback((err) => {
   assert.strictEqual(asyncLocalStorage.getStore().get('hello'), 'node');
 });
 
-asyncLocalStorage.run((str) => {
+asyncLocalStorage.run(() => {
   const store = asyncLocalStorage.getStore();
-  assert.strictEqual(str, 'hello');
   store.set('hello', 'node');
   setTimeout(() => {
     process.nextTick(() => {
@@ -24,4 +23,4 @@ asyncLocalStorage.run((str) => {
     throw new Error('err2');
   }, 0);
   throw new Error('err1');
-}, 'hello');
+});

--- a/test/async-hooks/test-async-local-storage-errors-sync-ret.js
+++ b/test/async-hooks/test-async-local-storage-errors-sync-ret.js
@@ -14,9 +14,8 @@ process.setUncaughtExceptionCaptureCallback((err) => {
 });
 
 try {
-  asyncLocalStorage.runSyncAndReturn((val) => {
+  asyncLocalStorage.runSyncAndReturn(() => {
     const store = asyncLocalStorage.getStore();
-    assert.strictEqual(val, 'str');
     store.set('hello', 'node');
     setTimeout(() => {
       process.nextTick(() => {
@@ -25,7 +24,7 @@ try {
       throw new Error('err2');
     }, 0);
     throw new Error('err1');
-  }, 'str');
+  });
 } catch (e) {
   assert.strictEqual(e.message, 'err1');
   assert.strictEqual(asyncLocalStorage.getStore(), undefined);


### PR DESCRIPTION
* Addresses nit comments from @Qard in https://github.com/nodejs/node/pull/26540
* Introduces a separate test (`test-async-local-storage-args.js`) that verifies proper propagation of optional arguments into callbacks for all `.run*()` and `.exit*()` methods